### PR TITLE
Further simplify python venv check

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -36,8 +36,7 @@
 ;; number for eshell prompt.
 
 ;; If you want to display the python virtual environment info, you
-;; need to install `virtualenvwrapper' and `virtualenvwrapper.el'.
-;; pip install virtualenvwrapper
+;; need to install `virtualenvwrapper.el'.
 ;; M-x: package-install: virtualenvwrapper
 
 ;; Installation
@@ -335,9 +334,8 @@ length of PATH (sans directory slashes) down to MAX-LEN."
      (epe-colorize-with-face
       (concat (epe-remote-user) "@" (epe-remote-host) " ")
       'epe-remote-face))
-   (when epe-show-python-info
-     (when (and (boundp 'venv-current-name) venv-current-name)
-       (epe-colorize-with-face (concat "(" venv-current-name ") ") 'epe-venv-face)))
+   (when (and epe-show-python-info (bound-and-true-p venv-current-name))
+     (epe-colorize-with-face (concat "(" venv-current-name ") ") 'epe-venv-face))
    (let ((f (cond ((eq epe-path-style 'fish) 'epe-fish-path)
                   ((eq epe-path-style 'single) 'epe-abbrev-dir-name)
                   ((eq epe-path-style 'full) 'abbreviate-file-name))))
@@ -388,9 +386,8 @@ length of PATH (sans directory slashes) down to MAX-LEN."
        (epe-colorize-with-face
         (concat (epe-remote-user) "@" (epe-remote-host) " ")
         'epe-remote-face))
-     (when epe-show-python-info
-       (when (and (boundp 'venv-current-name) venv-current-name)
-         (epe-colorize-with-face (concat "(" venv-current-name ") ") 'epe-venv-face)))
+     (when (and epe-show-python-info (bound-and-true-p venv-current-name))
+       (epe-colorize-with-face (concat "(" venv-current-name ") ") 'epe-venv-face))
      (epe-colorize-with-face (funcall
                               shrink-paths
                               (split-string
@@ -437,9 +434,8 @@ length of PATH (sans directory slashes) down to MAX-LEN."
     (epe-colorize-with-face  "]\n" 'epe-pipeline-delimiter-face)
     (epe-colorize-with-face "└─>" 'epe-pipeline-delimiter-face)
     )
-   (when epe-show-python-info
-     (when (and (boundp 'venv-current-name) venv-current-name)
-       (epe-colorize-with-face (concat "(" venv-current-name ") ") 'epe-venv-face)))
+   (when (and epe-show-python-info (bound-and-true-p venv-current-name))
+     (epe-colorize-with-face (concat "(" venv-current-name ") ") 'epe-venv-face))
    (when (epe-git-p)
      (concat
       (epe-colorize-with-face ":" 'epe-dir-face)


### PR DESCRIPTION
And remove `pip install virtualenvwrapper` in readme as it's not needed.